### PR TITLE
Allow defining which timePeriods we want to be calculated on Daily Files

### DIFF
--- a/MultiPeriodDaily.js
+++ b/MultiPeriodDaily.js
@@ -367,6 +367,18 @@
                             const timePeriod = global.dailyFilePeriods[n][0];
                             const outputPeriodLabel = global.dailyFilePeriods[n][1];
 
+                            if (processConfig.framework.validPeriods !== undefined) {
+                                let validPeriod = false;
+                                for (let i = 0; i < processConfig.framework.validPeriods.length; i++) {
+                                    let period = processConfig.framework.validPeriods[i];
+                                    if (period === outputPeriodLabel) { validPeriod = true }
+                                }
+                                if (validPeriod === false) {
+                                    periodsControlLoop();
+                                    return;
+                                }
+                            }   
+
                             let dependencyIndex = 0;
                             dataFiles = [];
 


### PR DESCRIPTION
I made a change so that the simulation only runs at 5, 10 and 15 minutes timePeriods. The reason is that currently it is not useful below 5 min (for the data delays) and betwhee 15 and 1hr it is unreliable, for the way the simulation is processed. 

To deploy remember to update the configs of Jason, and Trading Simulation Plotter.